### PR TITLE
Add dashboard for submitted papers

### DIFF
--- a/apps/contentstore/PaperBoy.ContentStore/Application/Projections/IPaperInfoRepository.cs
+++ b/apps/contentstore/PaperBoy.ContentStore/Application/Projections/IPaperInfoRepository.cs
@@ -4,4 +4,5 @@ public interface IPaperInfoRepository
 {
     Task<PaperInfo?> GetByIdAsync(Guid id);
     Task<PagedResult<PaperInfo>> GetAllAsync(int page, int pageSize);
+    Task<PagedResult<PaperInfo>> GetByStatusAsync(string[] statuses, int page, int pageSize);
 }

--- a/apps/contentstore/PaperBoy.ContentStore/Application/Projections/PaperInfoProjection.cs
+++ b/apps/contentstore/PaperBoy.ContentStore/Application/Projections/PaperInfoProjection.cs
@@ -12,6 +12,8 @@ public class PaperInfoProjection : EventProjection
         Project<PageSummaryGeneratedEvent>(OnPageSummaryGenerated);
         Project<SummaryGeneratedEvent>(OnPaperSummarized);
         Project<ScoreGeneratedEvent>(OnPaperScored);
+        Project<PaperDeclinedEvent>(OnPaperDeclined);
+        Project<DescriptionGeneratedEvent>(OnDescriptionGenerated);
     }
 
     private void OnPaperScored(ScoreGeneratedEvent @event, IDocumentOperations operations)
@@ -55,5 +57,22 @@ public class PaperInfoProjection : EventProjection
         };
 
         operations.Insert(paperInfo);
+    }
+
+    private void OnPaperDeclined(PaperDeclinedEvent @event, IDocumentOperations operations)
+    {
+        var paperInfo = operations.Load<PaperInfo>(@event.PaperId)!;
+        paperInfo.Status = Domain.PaperStatus.Declined;
+
+        operations.Update(paperInfo);
+    }
+
+    private void OnDescriptionGenerated(DescriptionGeneratedEvent @event, IDocumentOperations operations)
+    {
+        var paperInfo = operations.Load<PaperInfo>(@event.PaperId)!;
+        paperInfo.Status = Domain.PaperStatus.Approved;
+        paperInfo.Description = @event.Description;
+
+        operations.Update(paperInfo);
     }
 }

--- a/apps/contentstore/PaperBoy.ContentStore/Infrastructure/PaperInfoRepository.cs
+++ b/apps/contentstore/PaperBoy.ContentStore/Infrastructure/PaperInfoRepository.cs
@@ -18,4 +18,20 @@ public class PaperInfoRepository(IDocumentStore store) : IPaperInfoRepository
     {
         throw new NotImplementedException();
     }
+
+    public async Task<PagedResult<PaperInfo>> GetByStatusAsync(string[] statuses, int page, int pageSize)
+    {
+        var session = store.LightweightSession();
+        var query = session.Query<PaperInfo>().AsQueryable();
+
+        if (statuses.Length > 0)
+        {
+            query = query.Where(p => statuses.Contains(p.Status.ToString()));
+        }
+
+        var count = await query.CountAsync();
+        var results = await query.OrderBy(x => x.DateCreated).Skip(page * pageSize).Take(pageSize).ToListAsync();
+
+        return new PagedResult<PaperInfo>(results, page, pageSize, count);
+    }
 }

--- a/apps/contentstore/PaperBoy.ContentStore/Program.cs
+++ b/apps/contentstore/PaperBoy.ContentStore/Program.cs
@@ -147,9 +147,10 @@ app.MapGet("/papers/{paperId}", async (Guid paperId, IPaperRepository paperRepos
     return Results.Ok(paper);
 });
 
-app.MapGet("/papers", async (IPaperInfoRepository paperInfoRepository, [FromQuery] int page = 0) =>
+app.MapGet("/papers", async (IPaperInfoRepository paperInfoRepository, [FromQuery] string? status, [FromQuery] int page = 0) =>
 {
-    var papers = await paperInfoRepository.GetAllAsync(page, 20);
+    var statuses = status?.Split(',') ?? new string[0];
+    var papers = await paperInfoRepository.GetByStatusAsync(statuses, page, 20);
     return Results.Ok(papers);
 });
 

--- a/apps/dashboard/app/page.tsx
+++ b/apps/dashboard/app/page.tsx
@@ -1,3 +1,121 @@
-export default function Page() {
-  return <h1>Hello world</h1>;
+import { GetServerSideProps } from 'next';
+import { useState } from 'react';
+import axios from 'axios';
+import 'daisyui/dist/full.css';
+
+interface Paper {
+  id: string;
+  title: string;
+  submitter: {
+    name: string;
+    email: string;
+  };
+  url: string;
+  status: string;
+  sectionsSummarized: number;
+  totalSections: number;
 }
+
+interface Props {
+  papers: Paper[];
+  currentPage: number;
+  totalPages: number;
+}
+
+export const getServerSideProps: GetServerSideProps = async (context) => {
+  const page = context.query.page ? parseInt(context.query.page as string, 10) : 0;
+  const response = await axios.get(`http://localhost:3000/papers?page=${page}`);
+  const { data } = response;
+
+  return {
+    props: {
+      papers: data.items,
+      currentPage: page,
+      totalPages: Math.ceil(data.totalCount / 20),
+    },
+  };
+};
+
+const Page = ({ papers, currentPage, totalPages }: Props) => {
+  const [currentPapers, setCurrentPapers] = useState(papers);
+
+  const handleApprove = async (paperId: string) => {
+    await axios.post(`http://localhost:3000/papers/${paperId}/approve`);
+    setCurrentPapers(currentPapers.map(paper => paper.id === paperId ? { ...paper, status: 'approved' } : paper));
+  };
+
+  const handleDecline = async (paperId: string) => {
+    await axios.post(`http://localhost:3000/papers/${paperId}/decline`);
+    setCurrentPapers(currentPapers.map(paper => paper.id === paperId ? { ...paper, status: 'declined' } : paper));
+  };
+
+  return (
+    <div className="container mx-auto p-4">
+      <h1 className="text-2xl font-bold mb-4">Dashboard</h1>
+      <button className="btn btn-primary mb-4">Submit New Paper</button>
+      <div className="overflow-x-auto">
+        <table className="table w-full">
+          <thead>
+            <tr>
+              <th>Title</th>
+              <th>Submitter</th>
+              <th>URL</th>
+              <th>Status</th>
+              <th>Sections Summarized</th>
+              <th>Total Sections</th>
+              <th>Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {currentPapers.map((paper) => (
+              <tr key={paper.id}>
+                <td>{paper.title}</td>
+                <td>{paper.submitter.name}</td>
+                <td><a href={paper.url} target="_blank" rel="noopener noreferrer">{paper.url}</a></td>
+                <td><span className={`badge ${getStatusBadgeClass(paper.status)}`}>{paper.status}</span></td>
+                <td>{paper.sectionsSummarized}</td>
+                <td>{paper.totalSections}</td>
+                <td>
+                  {paper.status === 'scored' && (
+                    <>
+                      <button className="btn btn-success mr-2" onClick={() => handleApprove(paper.id)}>Approve</button>
+                      <button className="btn btn-error" onClick={() => handleDecline(paper.id)}>Decline</button>
+                    </>
+                  )}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <div className="flex justify-center mt-4">
+        <button className="btn" disabled={currentPage === 0} onClick={() => handlePageChange(currentPage - 1)}>Previous</button>
+        <span className="mx-2">Page {currentPage + 1} of {totalPages}</span>
+        <button className="btn" disabled={currentPage === totalPages - 1} onClick={() => handlePageChange(currentPage + 1)}>Next</button>
+      </div>
+    </div>
+  );
+
+  function getStatusBadgeClass(status: string) {
+    switch (status) {
+      case 'imported':
+        return 'badge-info';
+      case 'summarized':
+        return 'badge-warning';
+      case 'scored':
+        return 'badge-primary';
+      case 'approved':
+        return 'badge-success';
+      case 'declined':
+        return 'badge-error';
+      default:
+        return '';
+    }
+  }
+
+  function handlePageChange(page: number) {
+    window.location.href = `?page=${page}`;
+  }
+};
+
+export default Page;


### PR DESCRIPTION
Related to #9

Implement a dashboard to display a list of submitted papers with their respective statuses and pagination.

* **Dashboard Page (`apps/dashboard/app/page.tsx`)**
  - Fetch the list of papers from the `/papers` endpoint using `getServerSideProps`.
  - Display the papers in a `daisyui` table with pagination.
  - Show the status of each paper with a `daisyui` badge component.
  - Add buttons to approve or decline papers with the status `scored`.
  - Add a button at the top of the dashboard to submit a new paper.

* **Paper Info Repository (`apps/contentstore/PaperBoy.ContentStore/Application/Projections/IPaperInfoRepository.cs`)**
  - Add a method to get papers by status.

* **Content Store Program (`apps/contentstore/PaperBoy.ContentStore/Program.cs`)**
  - Update the `/papers` endpoint to support fetching papers with statuses imported, summarized, scored, or approved.

* **Paper Info Projection (`apps/contentstore/PaperBoy.ContentStore/Application/Projections/PaperInfoProjection.cs`)**
  - Update the paper status based on various events, including paper declined and description generated.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/wmeints/paperboy/issues/9?shareId=0aa0eaa8-0c17-4e0c-9abc-4cd8437ddcf8).