### PR TITLE
Add dapr CLI to the devcontainer

### DIFF
--- a/devcontainer.json
+++ b/devcontainer.json
@@ -3,6 +3,7 @@
   "features": {
     "ghcr.io/devcontainers/features/node:1": {
       "version": "20"
-    }
+    },
+    "ghcr.io/devcontainers/features/dapr-cli:1": {}
   }
 }


### PR DESCRIPTION
Related to #13

Add Dapr CLI support to the devcontainer.

* Modify `devcontainer.json` to include the Dapr CLI feature.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/wmeints/paperboy/issues/13?shareId=28eb0594-2742-4c6f-8678-8020491c09d4).